### PR TITLE
MS-208: added shared back btn for psychologist module

### DIFF
--- a/src/Components/Psychologist/CompletedInterviews/completed-interviews.module.css
+++ b/src/Components/Psychologist/CompletedInterviews/completed-interviews.module.css
@@ -19,22 +19,6 @@ table {
     margin-top: 40px;
     margin-bottom: 40px;
   }
-  .backBtn {
-    font: 1.1rem Century Gothic;
-    margin: 30px;
-    padding: 5px 15px;
-    background-color: #065500;
-    border-radius: 20px;
-    border: none;
-    color: #ffffff;
-    display: flex;
-    align-items: center;
-    box-shadow: 5px 9px 10px #68686842;
-  }
-  .backBtn:hover {
-    background-color:#002147;
-    color: #ffffff;
-  }
   .interviewsContent {
     margin-bottom: 40px;
   }

--- a/src/Components/Psychologist/CompletedInterviews/index.js
+++ b/src/Components/Psychologist/CompletedInterviews/index.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { getSessions } from 'redux/Sessions/thunks';
 import styles from './completed-interviews.module.css';
 import { FaCheckCircle, FaClock } from 'react-icons/fa';
+import Button from 'Components/Shared/Button';
 
 function CompletedInterviews() {
   const sessions = useSelector((state) => state.sessions.list);
@@ -14,7 +15,7 @@ function CompletedInterviews() {
   return (
     <section className={styles.container}>
       <div className={styles.containerInterviews}>
-        <button className={styles.backBtn}>BACK</button>
+        <Button type={'backBtnPsycho'} />
         <div className={styles.interviewsContent}>
           <h3 className={styles.title}>
             <span className={styles.bold}>Unassigned users:</span>

--- a/src/Components/Shared/Button/button.module.css
+++ b/src/Components/Shared/Button/button.module.css
@@ -120,3 +120,19 @@ cursor: pointer;
 .editInfo:hover {
   cursor: pointer;
 }
+.backBtnPsycho{
+  font: 1.1rem Century Gothic;
+  margin: 30px;
+  padding: 5px 15px;
+  background-color: #065500;
+  border-radius: 20px;
+  border: none;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  box-shadow: 5px 9px 10px #68686842;
+  cursor: pointer;
+}
+.backBtnPsycho:hover {
+  background-color:#002147;
+}

--- a/src/Components/Shared/Button/index.js
+++ b/src/Components/Shared/Button/index.js
@@ -39,6 +39,12 @@ function Button({ type, onClick, text }) {
           <FaPen className={styles.fapen} />
         </>
       )}
+      {type === 'backBtnPsycho' && (
+        <>
+          <FaAngleLeft size={25} />
+          {text}
+        </>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
Created a shared button for psychologist module. 
This button is used in the following branches:

1. MS-196
2. MS-197
3. MS-198
4. MS-199
5. MS-201 (with text that says "BACK")
6. MS-202

**The implementation is on the component CompletedInterviews**

![psychologist-back-btn](https://user-images.githubusercontent.com/82414508/147670642-50f14954-3fed-47bc-9aa6-e473a9dc826e.png)

